### PR TITLE
Add filetype detection plugin, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,26 @@
-glsl.vim
-========
+# glsl.vim
 
-OpenGL Shading Language (GLSL) Vim syntax highlighting
+OpenGL Shading Language (GLSL) Vim syntax highlighting.
 
-Instructions
------------------------------------------------------------
+## Instructions
 
-Using the Pathogen plugin:
-(http://vimcasts.org/episodes/synchronizing-plugins-with-git-submodules-and-pathogen/)
+Using the [Pathogen plugin](http://vimcasts.org/episodes/synchronizing-plugins-with-git-submodules-and-pathogen/):
 
-From your ~/.vim directory:
-> git submodule add git://github.com/beyondmarc/glsl.vim.git bundle/syntax\_glsl
+* From your `~/.vim` directory:
+
+   `git submodule add git://github.com/beyondmarc/glsl.vim.git bundle/glsl.vim`
 
 If not using the Pathogen plugin:
-* Add the glsl\*\*\*.vim files into your vim syntax folder (in most Linux distros:
-/usr/share/vim/vim\<version\>/syntax).
 
-Add the following line at the bottom of your .vimrc file:
+* Add this directory to your `runtimepath`, in your `.vimrc`:
 
-> autocmd BufNewFile,BufRead \*.vp,\*.fp,\*.gp,\*.vs,\*.fs,\*.gs,\*.tcs,\*.tes,\*.cs,\*.vert,\*.frag,\*.geom,\*.tess,\*.shd,\*.gls,\*.glsl set ft=glsl\*\*\*
+   `set rtp^=/path/to/glsl.vim`
 
+### Choosing the GLSL version to work with
+
+To set the default GLSL version for which the syntax is loaded, set the global
+variable `glsl_default_version` in your `.vimrc` before loading the plugin:
+
+    let g:glsl_default_version = 'glsl330'
+
+If this variable is not set, it will default to `glsl330`.

--- a/ftdetect/glsl.vim
+++ b/ftdetect/glsl.vim
@@ -1,0 +1,5 @@
+if !exists('g:glsl_default_version')
+    let g:glsl_default_version = 'glsl330'
+endif
+
+execute 'autocmd BufRead,BufNewFile *.vp,*.fp,*.gp,*.vs,*.fs,*.gs,*.tcs,*.tes,*.cs,*.vert,*.frag,*.geom,*.tess,*.shd,*.gls,*.glsl,*.vsh,*.fsh setfiletype '.g:glsl_default_version


### PR DESCRIPTION
This adds a `ftdetect` script that automatically loads the GLSL syntax highlighting. The user can configure which version to load using `g:glsl_default_version`.
